### PR TITLE
Fix "Constant expression expected" error on Haxe 3.3+

### DIFF
--- a/src/erazor/Parser.hx
+++ b/src/erazor/Parser.hx
@@ -20,7 +20,7 @@ private enum ParseResult {
 
 class Parser
 {
-	private static var at = '@';
+	private static inline var at = '@';
 
 	private var condMatch : EReg;
 	private var inConditionalMatch : EReg;


### PR DESCRIPTION
I found this while trying to compile latest haxelib website with latest haxe (see https://github.com/HaxeFoundation/haxelib/pull/256)
